### PR TITLE
Use kubeconfig for oc and virtctl commands

### DIFF
--- a/resources/namespace.py
+++ b/resources/namespace.py
@@ -21,4 +21,4 @@ class NameSpace(Resource):
         Returns:
             bool: True f switched , False otherwise
         """
-        return utils.run_command(command=f"oc project {self.name}")[0]
+        return utils.run_oc_command(command=f"project {self.name}")[0]

--- a/resources/pod.py
+++ b/resources/pod.py
@@ -34,7 +34,7 @@ class Pod(Resource):
         Returns:
             tuple: True, out if command succeeded, False, err otherwise.
         """
-        cmd = f"oc exec -i {self.name}"
+        cmd = f"exec -i {self.name}"
         if self.namespace:
             cmd += f" -n {self.namespace}"
 
@@ -42,7 +42,7 @@ class Pod(Resource):
             cmd += f" -c {container}"
 
         cmd += f" -- {command}"
-        return utils.run_command(command=cmd)
+        return utils.run_oc_command(command=cmd, namespace=self.namespace)
 
     def node(self):
         """

--- a/resources/resource.py
+++ b/resources/resource.py
@@ -14,7 +14,7 @@ SLEEP = 1
 
 
 class Resource(object):
-    def __init__(self):
+    def __init__(self, name=None, api_version=None, kind=None, namespace=None):
         urllib3.disable_warnings()
         try:
             kubeconfig = os.getenv('KUBECONFIG')
@@ -22,11 +22,11 @@ class Resource(object):
         except (kube_config.ConfigException, urllib3.exceptions.MaxRetryError):
             LOGGER.error('You need to be login to cluster or have $KUBECONFIG env configured')
             raise
-        
-        self.kind = None
-        self.namespace = None
-        self.api_version = None
-        self.name = None
+
+        self.kind = kind
+        self.namespace = namespace
+        self.api_version = api_version
+        self.name = name
 
     def get(self, **kwargs):
         """
@@ -144,7 +144,7 @@ class Resource(object):
                 data = yaml.full_load(stream)
 
             self._extract_data_from_yaml(yaml_data=data)
-            res = utils.run_command(command=f'oc create -f {yaml_file}')[0]
+            res = utils.run_oc_command(command=f'create -f {yaml_file}', namespace=self.namespace)[0]
             if wait and res:
                 return self.wait()
             return res
@@ -179,7 +179,7 @@ class Resource(object):
                 data = yaml.full_load(stream)
 
             self._extract_data_from_yaml(yaml_data=data)
-            res = utils.run_command(command=f'oc delete -f {yaml_file}')[0]
+            res = utils.run_oc_command(command=f'delete -f {yaml_file}', namespace=self.namespace)[0]
             if wait and res:
                 return self.wait_until_gone()
             return res

--- a/resources/virtual_machine.py
+++ b/resources/virtual_machine.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 
 import logging
-from tests import config
 from .resource import Resource, SLEEP, TIMEOUT
 from utilities import utils, types
 from autologs.autologs import generate_logs
@@ -14,17 +13,14 @@ class VirtualMachine(Resource):
     Virtual Machine object, inherited from Resource.
     Implements actions start / stop / status / wait for VM status / is running
     """
-    
+
     def __init__(self, name, namespace=None):
         super(VirtualMachine, self).__init__()
         self.name = name
         self.namespace = namespace
         self.api_version = types.CNV_API_VERSION
         self.kind = types.VM
-        self.cmd = f"{config.VIRTCTL_CMD}"
-        if self.namespace:
-            self.cmd += f" -n {self.namespace}"
-    
+
     @generate_logs()
     def start(self, timeout=TIMEOUT, sleep=SLEEP, wait=False):
         """
@@ -38,12 +34,11 @@ class VirtualMachine(Resource):
             True if VM started, else False
 
         """
-        cmd_start = f"{self.cmd} start {self.name}"
-        res = utils.run_command(command=cmd_start)[0]
+        res = utils.run_virtctl_command(command="start", namespace=self.namespace)[0]
         if wait and res:
             return self.wait_for_status(sleep=sleep, timeout=timeout, status=True)
         return res
-    
+
     @generate_logs()
     def stop(self, timeout=TIMEOUT, sleep=SLEEP, wait=False):
         """
@@ -57,12 +52,11 @@ class VirtualMachine(Resource):
             bool: True if VM stopped, else False
 
         """
-        cmd_stop = f"{self.cmd} stop {self.name}"
-        res = utils.run_command(command=cmd_stop)[0]
+        res = utils.run_virtctl_command(command="stop", namespace=self.namespace)[0]
         if wait and res:
             return self.wait_for_status(sleep=sleep, timeout=timeout, status=False)
         return res
-            
+
     @generate_logs()
     def wait_for_status(self, status, timeout=TIMEOUT, sleep=SLEEP, **kwargs):
         """

--- a/tests/config.py
+++ b/tests/config.py
@@ -1,9 +1,6 @@
 TEST_NS = "kubevirt-test-default"
 TEST_NS_ALTERNATIVE = "kubevirt-test-alternative"
 
-#VIRTCTL
-VIRTCTL_CMD = "virtctl"
-
 # VM distro
 FEDORA_VM = "fedora"
 CIRROS_VM = "cirros"


### PR DESCRIPTION
We support --kubeconfig when calling ocp_client, if the test use
$KUBECONFIG it will fail to run oc and virtctl. This PR add --kubeconfig
if exists to oc and virtctl command.